### PR TITLE
Update to latest libopencm3

### DIFF
--- a/code/veccart/Dockerfile
+++ b/code/veccart/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-arm-embedded
 WORKDIR /build
 RUN git clone https://github.com/libopencm3/libopencm3.git \
     && cd libopencm3 \
-    && git checkout 9b8d44e8a3cc52d83aba3b5547c2bb56cdbd8b63 \
+    && git checkout f7a952c41a815572622f137881af6160730a3768 \
     && make
 
 WORKDIR /build/veccart

--- a/code/veccart/main.c
+++ b/code/veccart/main.c
@@ -22,7 +22,6 @@
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/stm32/exti.h>
 #include <libopencm3/cm3/nvic.h>
-#include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/pwr.h>
 #include <libopencm3/stm32/flash.h>
 #include <stdlib.h>
@@ -183,7 +182,24 @@ static FATFS FatFs;
 int main(void) {
 	void (*runptr)(void)=romemu;
 
-	rcc_clock_setup_hse_3v3(&hse_8mhz_3v3[CLOCK_3V3_120MHZ]);
+  const struct rcc_clock_scale hse_8mhz_3v3_120MHz = { /* 120MHz */
+     .pllm = 8,
+     .plln = 240,
+     .pllp = 2,
+     .pllq = 5,
+     .pllr = 0,
+     .pll_source = RCC_CFGR_PLLSRC_HSE_CLK,
+     .hpre = RCC_CFGR_HPRE_DIV_NONE,
+     .ppre1 = RCC_CFGR_PPRE_DIV_4,
+     .ppre2 = RCC_CFGR_PPRE_DIV_2,
+     .voltage_scale = PWR_SCALE1,
+     .flash_config = FLASH_ACR_ICEN | FLASH_ACR_DCEN | FLASH_ACR_LATENCY_3WS,
+     .ahb_frequency  = 120000000,
+     .apb1_frequency = 30000000,
+     .apb2_frequency = 60000000,
+  };
+
+	rcc_clock_setup_pll(&hse_8mhz_3v3_120MHz);
 	rcc_periph_clock_enable(RCC_GPIOA);
 	rcc_periph_clock_enable(RCC_GPIOB);
 	rcc_periph_clock_enable(RCC_GPIOC);

--- a/code/veccart/stm32f411rct6.ld
+++ b/code/veccart/stm32f411rct6.ld
@@ -6,4 +6,4 @@ rom (rx) : ORIGIN = 0x08000000, LENGTH = 256K
 ram (rwx) : ORIGIN = 0x20000400, LENGTH = 127K
 }
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f4.ld
+INCLUDE cortex-m-generic.ld


### PR DESCRIPTION
### Problem

In the initial attempt to port SpriteTM's work, I found the commit nearest his patch to libopencm3. At this point, that is ~4 years old. We don't wanna be pinned to an old outdated version of the library, so let's update to latest and fix up any issues.

### Solution

This has the necessary changes to build against current libopencm3 (f7a952c41a815572622f137881af6160730a3768). There's a breaking change in how you initialize the clock on the stm32, and it seems they removed the description for 120MHz from the headers. I've tried to reconstruct the pieces by looking at various checkouts of the library and filling in the gaps.

### Steps to Test

This will have to be manually tested.

### References

### Contributor License Agreement

I, Bradon Kanyid, agree to licence my contributions to this project under the terms of the GPL 3.0 or any later version.