### PR TITLE
Menu fixes

### DIFF
--- a/code/multicart/multicart.asm
+++ b/code/multicart/multicart.asm
@@ -279,11 +279,10 @@ init_page_cursor
                     lda      lastselcart
                     anda     #3
                     sta      cursor
-                    lda      lastselcart
-                    lsra
-                    lsra
-                    lsra
-                    sta      page
+                    lda      lastselcart                  ; (lastselcart / 4) = page
+                    lsra                                  ;  |
+                    lsra                                  ;  |
+                    sta      page                         ;  |
                     rts
 
 ;Rpc function. Because this makes the cart unavailable, this


### PR DESCRIPTION
### Problem

- After playing a game and resetting it, you end up back a few pages in the menu
- If directory listing ended with 4 items on the last page, a new blank page is allowed to be traveled to

### Solution

- `page` was being divided by 8 instead of 4, resulting in ending up further back
- Before incrementing `page`, test if an increment would result in the end of listing data (null pointer), and just set `lastpage = 1` to prevent further testing.

### Steps to Test

- Play a game like Web Wars deep in the pages, and reset... see if you end up again on Web Wars
- Check directory listings that end perfectly with 4 items and see if you can still page right any more

---

### Contributor License Agreement

I, Brett Walach, agree to license my contributions to this project under the terms of the [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) or any later version.

>Please add your full legal name above, for this PR to be mergeable.  If you would prefer to sign a CLA via email, please request that.
