### PR TITLE
New stm32 build container with uf2 bootloader

### DIFF
--- a/code/stm32/Dockerfile
+++ b/code/stm32/Dockerfile
@@ -1,14 +1,30 @@
-FROM archlinux:20200605
-LABEL Description="STM32 and libopencm3"
-
-RUN pacman -Syu --noconfirm \
- && pacman -S make git python --noconfirm \
- && pacman -S arm-none-eabi-gcc arm-none-eabi-binutils arm-none-eabi-newlib --noconfirm
+FROM frolvlad/alpine-glibc:glibc-2.33
 
 WORKDIR /build
-RUN git clone https://github.com/libopencm3/libopencm3.git \
-    && cd libopencm3 \
-    && git checkout 90753950bbe10e87b8caabfb0bd6e1d195bb24b8 \
-    && TARGETS=stm32/f4 make
+
+RUN apk --update --no-cache upgrade && \
+    # Base utils \
+    apk --update --no-cache add make && \
+    apk --update --no-cache add python2 && \
+    apk --update --no-cache add python3 && \
+    apk --update --no-cache add bash && \
+    apk --update --no-cache add --virtual build-dependencies wget openssl ca-certificates git && \
+    # Install arm-none-eabi-gcc \
+    wget -O /tmp/gcc-arm-none-eabi.tar.bz2 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2" && \
+    tar xvf /tmp/gcc-arm-none-eabi.tar.bz2 --strip-components=1 -C /usr/local && \
+    rm -rf /tmp/gcc-arm-none-eabi.tar.bz2 && \
+    rm -rf /usr/local/share/doc && \
+    # Install libopencm3 \
+    git clone https://github.com/libopencm3/libopencm3.git && \
+    cd libopencm3 && \
+    git checkout 90753950bbe10e87b8caabfb0bd6e1d195bb24b8 && \
+    TARGETS=stm32/f4 make && \
+    # Install uf2conf.py \
+    wget -O /tmp/uf2conv.py https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2conv.py && \
+    mv /tmp/uf2conv.py /usr/local/bin/uf2conv.py && \
+    chmod +x /usr/local/bin/uf2conv.py && \
+    wget -O /usr/local/bin/uf2families.json https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2families.json && \
+    # Cleanup \
+    apk del build-dependencies
 
 WORKDIR /build/stm32

--- a/code/stm32/Makefile
+++ b/code/stm32/Makefile
@@ -4,6 +4,10 @@
 VERBOSE=@
 VERBOSE_REDIRECT= > /dev/null 2>&1
 
+DOCKER_ARGS=--rm -t -v `pwd`:/build/stm32 -u `id -u ${USER}`:`id -g ${USER}`
+STM_DOCKER=docker run ${DOCKER_ARGS} stm32-build
+STM_DOCKER_I=docker run -i ${DOCKER_ARGS} stm32-build
+
 # define a symbol MAKE_OS for the current operating system
 # WINDOWS | LINUX | OSX
 ifeq ($(OS),Windows_NT)
@@ -43,6 +47,16 @@ endif
 CFLAGS += -DHW_VER=$(HW_VER_VAL)
 ASFLAGS += -DHW_VER=$(HW_VER_VAL)
 
+ifeq ($(USE_UF2),1)
+UF2_VAL=1
+UF2_ARGS="USE_UF2=1"
+LDSCRIPT=stm32f411rct6-uf2.ld
+else
+UF2_VAL=0
+UF2_ARGS="USE_UF2=0"
+LDSCRIPT=stm32f411rct6.ld
+endif
+
 BINARY=stm32
 OBJS=main.o menu.o romemu.o msc.o xprintf.o usb_msc.o ff_diskio.o \
 		fatfs/ff.o fatfs/option/unicode.o flash.o led.o delay.o \
@@ -63,9 +77,6 @@ CFLAGS		+= -O3 -g -Wextra -Wshadow -Wimplicit-function-declaration -Wredundant-d
 		-Wmissing-prototypes -Wstrict-prototypes -fno-common -ffunction-sections -fdata-sections \
 		-MD -Wall -Wundef -I$(TOOLCHAIN_DIR)/include $(ARCH_FLAGS)
 ASFLAGS	+= $(ARCH_FLAGS)
-
-LDSCRIPT	= stm32f411rct6.ld
-#../libopencm3/lib/lib$(LIBNAME).ld
 
 LDFLAGS		+= --static -nostartfiles -L$(TOOLCHAIN_DIR)/lib  \
 		   -Xlinker -Map=$(BINARY).map -T$(LDSCRIPT) -Wl,--gc-sections -mthumb $(CFLAGS) -lm \
@@ -94,11 +105,14 @@ docker-build: Dockerfile
 	docker build . -t stm32-build
 
 docker:
-	docker run --rm -t -v `pwd`:/build/stm32 -u `id -u ${USER}`:`id -g ${USER}` stm32-build make images $(HW_VER_ARGS)
+	${STM_DOCKER} make images $(HW_VER_ARGS) $(UF2_ARGS)
+
+uf2: $(BINARY).bin
+	${STM_DOCKER} uf2conv.py -b 0x08008000 -o $(BINARY).uf2 -c $(BINARY).bin
 
 # '$ make bash' puts you in the docker container interactive shell for debugging
 bash:
-	docker run --rm -it -v `pwd`:/build/stm32 -u `id -u ${USER}`:`id -g ${USER}` stm32-build bash
+	${STM_DOCKER_I} bash
 
 images: $(BINARY).images
 flash: $(BINARY).flash

--- a/code/stm32/stm32f411rct6-uf2.ld
+++ b/code/stm32/stm32f411rct6-uf2.ld
@@ -1,0 +1,23 @@
+
+/* Define memory regions. */
+MEMORY
+{
+rom (rx) : ORIGIN = 0x08000000 + 32K, LENGTH = 256K - 32K
+ram (rwx) : ORIGIN = 0x20000400, LENGTH = 127K
+}
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld
+
+SECTIONS {
+    .text : {
+
+        /* ... */
+
+        menu_start = .;
+        INCLUDE "menu.ld" ;
+        menu_end = .;
+
+       /* ... */
+    }
+}
+


### PR DESCRIPTION
### Problem

The Arch-based stm32-build docker image started using gcc 11, which broke the linkerscript hack to embed the menu into the firmware.

### Solution

I made a new Dockerfile that is alpine-based, uses arm-none-eabi-gcc 10.2, and also includes uf2conv.py for future UF2 support

### Steps to Test

run `make docker-build` to build the new stm32-build container

for non-UF2 firmware, use the previous process:
`make clean all USE_HW=v0.3`

for UF2 firmware, use the following command:
`make clean all uf2 USE_HW=v0.3 USE_UF2=1`

## Setup VEXTREME for UF2

- git clone https://github.com/rattboi/uf2-stm32f
- cd uf2-stm32f
- make clean all BOARD=vextreme
- VEXTREME in DFU mode
- dfu-util -a 0 -d 0483:df11 -s 0x08000000:leave -D build/vextreme/bootloader.bin
- Board will mount and show up as VX-BOOT
- In VEXTREME/code/stm32 folder
- make clean all uf2 USE_HW=v1.0 USE_UF2=1
- Drag and drop stm32.uf2 into VX-BOOT drive
- Should reboot into VEXTREME drive, ready to put roms/ folder and games.

---

### Contributor License Agreement

I, `Bradon Kanyid`, agree to license my contributions to this project under the terms of the [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) or any later version.

>Please add your full legal name above, for this PR to be mergeable.  If you would prefer to sign a CLA via email, please request that.
